### PR TITLE
feat: remove extra arch + refactor unit tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,6 @@ name: Unittests
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches:
       - "master"
@@ -10,7 +9,7 @@ on:
 jobs:
   unittests:
     strategy:
-      env:
+      matrix:
         os: [ubuntu-latest]
         python-version: [3.10]
         torch-version: [2.0.1, 2.1.1, 2.2.1, 2.3.1, 2.4.1]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,9 +10,9 @@ jobs:
   unittests:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: [3.10]
-        torch-version: [2.0.1, 2.1.1, 2.2.1, 2.3.1, 2.4.1]
+        os: ["ubuntu-latest"]
+        python-version: ["3.10"]
+        torch-version: ["2.0.1", "2.1.1", "2.2.1", "2.3.1", "2.4.1"]
     runs-on: ${{ matrix.os }}
     steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
         - name: Install dependencies
           run: |
               python -m pip install --upgrade pip
-              pip install numpy scikit-learn flake8 setuptools numba
+              pip install "numpy==1.26.4" scikit-learn flake8 setuptools numba
         - name: Install Torch ${{ matrix.torch-version }}
           run: pip install torch==${{ matrix.torch-version }}+cpu -f https://download.pytorch.org/whl/torch
         - name: Build package

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
               python -m pip install --upgrade pip
               pip install numpy scikit-learn flake8 setuptools numba
         - name: Install Torch ${{ matrix.torch-version }}
-          run: pip install torch==${{ matrix.torch-version }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          run: pip install torch==${{ matrix.torch-version }}+cpu -f https://download.pytorch.org/whl/torch
         - name: Build package
           run: |
               python setup.py build_ext --inplace

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,9 +2,10 @@ name: Unittests
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches:
-      - master
+      - "master"
 
 jobs:
   unittests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,10 +9,10 @@ on:
 jobs:
   unittests:
     strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8]
-        torch-version: [1.10.0, 1.11.0, 1.12.0]
+      env:
+        os: [ubuntu-latest]
+        python-version: [3.10]
+        torch-version: [2.0.1, 2.1.1, 2.2.1, 2.3.1, 2.4.1]
     runs-on: ${{ matrix.os }}
     steps:
         - uses: actions/checkout@v2
@@ -23,15 +23,9 @@ jobs:
         - name: Install dependencies
           run: |
               python -m pip install --upgrade pip
-              pip install "numpy<=1.21" scikit-learn flake8 setuptools numba
-
-        - name: Install torch ${{ matrix.torch-version }} windows + linux
-          if: ${{matrix.os != 'macos-latest'}}
+              pip install numpy scikit-learn flake8 setuptools numba
+        - name: Install Torch ${{ matrix.torch-version }}
           run: pip install torch==${{ matrix.torch-version }}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-        - name: Install torch ${{ matrix.torch-version }} macos
-          if: ${{matrix.os == 'macos-latest'}}
-          run: pip install torch==${{ matrix.torch-version }}
-
         - name: Build package
           run: |
               python setup.py build_ext --inplace

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ build
 .vscode/
 dist/
 torch_points_kernels.egg-info/
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def get_ext_modules():
     if WITH_CUDA:
         nvcc_flags = os.getenv("NVCC_FLAGS", "")
         nvcc_flags = [] if nvcc_flags == "" else nvcc_flags.split(" ")
-        nvcc_flags += ["-arch=sm_35", "--expt-relaxed-constexpr", "-O2"]
+        nvcc_flags += ["--expt-relaxed-constexpr", "-O2"]
         extra_compile_args["nvcc"] = nvcc_flags
 
         ext_modules.append(


### PR DESCRIPTION
CUDA 12 is not compatible with some of the older GPU architectures, namely:
> Allowed values for this option:  'all','all-major','compute_50','compute_52',
 'compute_53','compute_60','compute_61','compute_62','compute_70','compute_72',
 'compute_75','compute_80','compute_86','compute_87','compute_89','compute_90',
 'compute_90a','lto_50','lto_52','lto_53','lto_60','lto_61','lto_62','lto_70',
 'lto_72','lto_75','lto_80','lto_86','lto_87','lto_89','lto_90','lto_90a',
 'native','sm_50','sm_52','sm_53','sm_60','sm_61','sm_62','sm_70','sm_72',
 'sm_75','sm_80','sm_86','sm_87','sm_89','sm_90','sm_90a'.

_torch-points-kernels_ setup file explicitly adds support for the architecture `sm_35` for a currently unknown reason ([see more context](https://promaton.slack.com/archives/C01N41CRE83/p1727689583853859?thread_ts=1727682257.039839&cid=C01N41CRE83)).

This PR removes this additional build flag.

Also, I refactored unit tests workflow to adjust some stuff to our current setup.

The plan is to issue a new release, `0.7.2` after merging this.