### PR TITLE
fix: correct setup.py version + run unit tests on Ubuntu 22.04

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
   unittests:
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-22.04"]
         python-version: ["3.10"]
         torch-version: ["2.0.1", "2.1.1", "2.2.1", "2.3.1", "2.4.1"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
         - name: Install dependencies
           run: |
               python -m pip install --upgrade pip
-              pip install numpy scikit-learn flake8 setuptools numba
+              pip install "numpy==1.26.4" scikit-learn flake8 setuptools numba
         - name: Install Torch ${{ matrix.torch-version }}
           run: pip install torch==${{ matrix.torch-version }}+cpu -f https://download.pytorch.org/whl/torch
         - name: Build package

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
         - name: Install dependencies
           run: |
               python -m pip install --upgrade pip
-              pip install "numpy==1.26.4" scikit-learn flake8 setuptools numba
+              pip install numpy scikit-learn flake8 setuptools numba
         - name: Install Torch ${{ matrix.torch-version }}
           run: pip install torch==${{ matrix.torch-version }}+cpu -f https://download.pytorch.org/whl/torch
         - name: Build package

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 requirements = ["torch>=1.1.0", "numba", "numpy", "scikit-learn"]
 
 url = "https://github.com/nicolas-chaulet/torch-points-kernels"
-__version__ = "0.7.2+cu121"
+__version__ = "0.7.3"
 setup(
     name="torch-points-kernels",
     version=__version__,


### PR DESCRIPTION
This PR syncs the version in _setup.py_ with the [latest release](https://github.com/promaton/torch-points-kernels/releases/tag/v0.7.3).